### PR TITLE
Circular linked list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
   - `Remoção` para recursos removidos.
   - `Correção` para correções.
 
+## 1.0.6 - 2023-04-27
+
+### Implementação
+
+- Adicionado classe `CircularLinkedList` para criação de listas circulares ligadas.
+
+Listas circulares ligadas são uma coleção de itens ordenados que seguem o principio (LIFO) Last In First Out, ou seja, o ultimo elemento a entrar é o primeiro a sair. As operações básicas de uma lista circulares ligada são: `append` (adicionar um elemento no final da lista), `prepend` (adicionar um elemento no inicio da lista), `insert` (adicionar um elemento em uma posição especifica da lista), `remove` (remover um elemento da lista) e `search` (retornar a posição de um elemento na lista). A diferença entre uma lista circular ligada e uma lista ligada é que na lista circular ligada o ultimo elemento possui uma referencia para o primeiro elemento.
+
+Explicação grafica de como funciona uma lista circular ligada:
+![image](https://user-images.githubusercontent.com/60474834/235025916-ac1e947a-761c-4da1-9d52-8e3ed52b5e59.png)
+
+---
+
 ## 1.0.5 - 2023-04-27
 
 ### Implementação

--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ Listas duplamente ligadas são uma coleção de itens ordenados que seguem o pri
 
 Explicação grafica de como funciona uma lista duplamente ligada:
 ![image](https://user-images.githubusercontent.com/60474834/235016219-4227efa3-c728-408a-91af-16fc21563bed.png)
+
+### Lista Circular Ligada
+
+Listas circulares ligadas são uma coleção de itens ordenados que seguem o principio (LIFO) Last In First Out, ou seja, o ultimo elemento a entrar é o primeiro a sair. As operações básicas de uma lista circulares ligada são: `append` (adicionar um elemento no final da lista), `prepend` (adicionar um elemento no inicio da lista), `insert` (adicionar um elemento em uma posição especifica da lista), `remove` (remover um elemento da lista) e `search` (retornar a posição de um elemento na lista). A diferença entre uma lista circular ligada e uma lista ligada é que na lista circular ligada o ultimo elemento possui uma referencia para o primeiro elemento.
+
+Explicação grafica de como funciona uma lista circular ligada:
+![image](https://user-images.githubusercontent.com/60474834/235025916-ac1e947a-761c-4da1-9d52-8e3ed52b5e59.png)

--- a/circular-linked-list/index.js
+++ b/circular-linked-list/index.js
@@ -1,0 +1,115 @@
+class CircularLinkedList {
+    constructor() {
+        this.head = null;
+        this.tail = null;
+    }
+
+    append(value) {
+        const newNode = { value: value, next: null };
+
+        if (this.tail) {
+            this.tail.next = newNode;
+        }
+
+        this.tail = newNode;
+
+        if (!this.head) {
+            this.head = newNode;
+        }
+
+        this.tail.next = this.head;
+    }
+
+    prepend(value) {
+        const newNode = { value: value, next: this.head };
+
+        this.head = newNode;
+
+        if (!this.tail) {
+            this.tail = newNode;
+        }
+
+        this.tail.next = this.head;
+    }
+
+    insert(value, index) {
+        if (index === 0) {
+            this.prepend(value);
+            return;
+        }
+
+        const newNode = { value: value, next: null };
+
+        const leader = this.traverseToIndex(index - 1);
+
+        const holdingPointer = leader.next;
+
+        leader.next = newNode;
+
+        newNode.next = holdingPointer;
+    }
+
+    traverseToIndex(index) {
+        let counter = 0;
+
+        let currentNode = this.head;
+
+        while (counter !== index) {
+            currentNode = currentNode.next;
+            counter++;
+        }
+
+        return currentNode;
+    }
+
+
+    remove(value) {
+        if (!this.head) {
+            return null;
+        }
+
+        if (this.head.value === value) {
+            this.head = this.head.next;
+            this.tail.next = this.head;
+            return;
+        }
+
+        let currentNode = this.head;
+
+        while (currentNode.next) {
+            if (currentNode.next.value === value) {
+                currentNode.next = currentNode.next.next;
+                return;
+            }
+
+            currentNode = currentNode.next;
+        }
+
+        if (this.tail.value === value) {
+            this.tail = currentNode;
+            this.tail.next = this.head;
+        }
+    }
+
+    search(value) {
+        if (!this.head) {
+            return null;
+        }
+
+        let currentNode = this.head;
+
+        while (currentNode) {
+            if (currentNode.value === value) {
+                return currentNode;
+            }
+
+            if (currentNode.next === this.head) {
+                return null;
+            }
+
+            currentNode = currentNode.next;
+        }
+    }
+}
+
+module.exports = CircularLinkedList;

--- a/circular-linked-list/test/index.test.js
+++ b/circular-linked-list/test/index.test.js
@@ -1,0 +1,53 @@
+const { describe } = require("node:test");
+const CircularLinkedList = require("../index");
+
+describe('Circular Linked List', () => {
+    
+    
+    // Tests that append method adds a new node to the end of the list with valid input. 
+    it("test_append_valid_input", () => {
+        const cll = new CircularLinkedList();
+        cll.append(1);
+        cll.append(2);
+        expect(cll.head.value).toBe(1);
+        expect(cll.tail.value).toBe(2);
+        expect(cll.tail.next).toBe(cll.head);
+    });
+
+    // Tests that prepend method adds a new node to the beginning of an empty list. 
+    it("test_prepend_empty_list", () => {
+        const cll = new CircularLinkedList();
+        cll.prepend(1);
+        expect(cll.head.value).toBe(1);
+        expect(cll.tail.value).toBe(1);
+        expect(cll.tail.next).toBe(cll.head);
+    });
+
+    // Tests that insert method adds a new node to the beginning of the list when index is 0. 
+    it("test_insert_index_0", () => {
+        const cll = new CircularLinkedList();
+        cll.insert(1, 0);
+        expect(cll.head.value).toBe(1);
+        expect(cll.tail.value).toBe(1);
+        expect(cll.tail.next).toBe(cll.head);
+    });
+
+    // Tests that remove method removes the head node correctly. 
+    it("test_remove_head_node", () => {
+        const cll = new CircularLinkedList();
+        cll.append(1);
+        cll.append(2);
+        cll.remove(1);
+        expect(cll.head.value).toBe(2);
+        expect(cll.tail.value).toBe(2);
+        expect(cll.tail.next).toBe(cll.head);
+    });
+
+    // Tests that search method returns null when searching for a non-existent value. 
+    it("test_search_non_existent_value", () => {
+        const cll = new CircularLinkedList();
+        cll.append(1);
+        cll.append(2);
+        expect(cll.search(3)).toBe(null);
+    });
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algorithms",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "study of algorithms",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adicionado classe `CircularLinkedList` para criação de listas circulares ligadas.

Listas circulares ligadas são uma coleção de itens ordenados que seguem o principio (LIFO) Last In First Out, ou seja, o ultimo elemento a entrar é o primeiro a sair. As operações básicas de uma lista circulares ligada são: `append` (adicionar um elemento no final da lista), `prepend` (adicionar um elemento no inicio da lista), `insert` (adicionar um elemento em uma posição especifica da lista), `remove` (remover um elemento da lista) e `search` (retornar a posição de um elemento na lista). A diferença entre uma lista circular ligada e uma lista ligada é que na lista circular ligada o ultimo elemento possui uma referencia para o primeiro elemento.

Explicação grafica de como funciona uma lista circular ligada:
![image](https://user-images.githubusercontent.com/60474834/235025916-ac1e947a-761c-4da1-9d52-8e3ed52b5e59.png)
